### PR TITLE
Crystal support

### DIFF
--- a/ament_cmake_export_crates/package.xml
+++ b/ament_cmake_export_crates/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>ament_cmake_export_crates</name>
-  <version>0.0.3</version>
+  <version>0.2.0</version>
   <description>The ability to export Rust crates to downstream packages in the ament buildsystem in CMake.</description>
   <author email="esteve@apache.org">Esteve Fernandez</author>
   <maintainer email="esteve@apache.org">Esteve Fernandez</maintainer>

--- a/rclrs/package.xml
+++ b/rclrs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>rclrs</name>
-  <version>0.0.3</version>
+  <version>0.2.0</version>
   <description>Package containing the Rust client.</description>
   <author email="esteve@apache.org">Esteve Fernandez</author>
   <maintainer email="esteve@apache.org">Esteve Fernandez</maintainer>

--- a/rclrs/src/c/rclrs.c
+++ b/rclrs/src/c/rclrs.c
@@ -4,15 +4,27 @@
 #include <rcl/error_handling.h>
 #include <rcl/rcl.h>
 
-bool rclrs_native_ok() { return rcl_ok(); }
+rcl_context_t ctx;
 
 int32_t rclrs_native_init() {
   // TODO(esteve): parse args
-  return rcl_init(0, NULL, rcl_get_default_allocator());
+  rcl_init_options_t opts;
+  ctx = rcl_get_zero_initialized_context();
+  rcl_ret_t ret;
+  ret = rcl_init_options_init(&opts, rcl_get_default_allocator());
+  if(ret!=RCL_RET_OK || ret!=RCL_RET_ALREADY_INIT) { return ret; }
+
+  ret = rcl_init(0, NULL, &opts, &ctx);
+  if(ret!=RCL_RET_OK || ret!=RCL_RET_ALREADY_INIT) { return ret; }
+
+  ret = rcl_init_options_fini(&opts);
+  if(ret!=RCL_RET_OK) { return ret; }
+
+  return RCL_RET_OK;
 }
 
 const char *rclrs_native_get_error_string_safe() {
-  return rcl_get_error_string_safe();
+  return rcl_get_error_string().str;
 }
 
 void rclrs_native_reset_error() { rcl_reset_error(); }
@@ -24,7 +36,7 @@ int32_t rclrs_native_create_node_handle(uintptr_t *node_handle,
   *node = rcl_get_zero_initialized_node();
 
   rcl_node_options_t default_options = rcl_node_get_default_options();
-  rcl_ret_t ret = rcl_node_init(node, name, namespace, &default_options);
+  rcl_ret_t ret = rcl_node_init(node, name, namespace, &ctx, &default_options);
   *node_handle = (uintptr_t)node;
   return ret;
 }
@@ -95,21 +107,21 @@ int32_t rclrs_native_wait_set_init(uintptr_t wait_set_handle,
 
 int32_t rclrs_native_wait_set_clear_subscriptions(uintptr_t wait_set_handle) {
   rcl_wait_set_t *wait_set = (rcl_wait_set_t *)wait_set_handle;
-  rcl_ret_t ret = rcl_wait_set_clear_subscriptions(wait_set);
+  rcl_ret_t ret = rcl_wait_set_clear(wait_set);
 
   return ret;
 }
 
 int32_t rclrs_native_wait_set_clear_services(uintptr_t wait_set_handle) {
   rcl_wait_set_t *wait_set = (rcl_wait_set_t *)wait_set_handle;
-  rcl_ret_t ret = rcl_wait_set_clear_services(wait_set);
+  rcl_ret_t ret = rcl_wait_set_clear(wait_set);
 
   return ret;
 }
 
 int32_t rclrs_native_wait_set_clear_clients(uintptr_t wait_set_handle) {
   rcl_wait_set_t *wait_set = (rcl_wait_set_t *)wait_set_handle;
-  rcl_ret_t ret = rcl_wait_set_clear_clients(wait_set);
+  rcl_ret_t ret = rcl_wait_set_clear(wait_set);
 
   return ret;
 }
@@ -118,7 +130,7 @@ int32_t rclrs_native_wait_set_add_subscription(uintptr_t wait_set_handle,
                                                uintptr_t subscription_handle) {
   rcl_wait_set_t *wait_set = (rcl_wait_set_t *)wait_set_handle;
   rcl_subscription_t *subscription = (rcl_subscription_t *)subscription_handle;
-  rcl_ret_t ret = rcl_wait_set_add_subscription(wait_set, subscription);
+  rcl_ret_t ret = rcl_wait_set_add_subscription(wait_set, subscription, NULL);
 
   return ret;
 }
@@ -160,7 +172,7 @@ int32_t rclrs_native_create_subscription_handle(
 
 int32_t rclrs_native_take(uintptr_t subscription_handle, uintptr_t message_handle) {
   rcl_subscription_t * subscription = (rcl_subscription_t *)subscription_handle;
-  void * taken_msg = message_handle;
+  void * taken_msg = (void *)message_handle;
 
   rcl_ret_t ret = rcl_take(subscription, taken_msg, NULL);
 

--- a/rclrs/src/rust/Cargo.toml.in
+++ b/rclrs/src/rust/Cargo.toml.in
@@ -1,6 +1,6 @@
 [package]
 name = "rclrs"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Esteve Fernandez <esteve@apache.org>"]
 
 [dependencies]

--- a/rclrs_common/Cargo.toml
+++ b/rclrs_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rclrs_common"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Esteve Fernandez <esteve@apache.org>"]
 
 [dependencies]

--- a/rclrs_common/package.xml
+++ b/rclrs_common/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>rclrs_common</name>
-  <version>0.0.3</version>
+  <version>0.2.0</version>
   <description>Common files for the Rust client.</description>
   <author email="esteve@apache.org">Esteve Fernandez</author>
   <maintainer email="esteve@apache.org">Esteve Fernandez</maintainer>

--- a/rclrs_examples/Cargo.toml
+++ b/rclrs_examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rclrs_examples"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Esteve Fernandez <esteve@apache.org>"]
 
 [[bin]]

--- a/rclrs_examples/package.xml
+++ b/rclrs_examples/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>rclrs_examples</name>
-  <version>0.0.0</version>
+  <version>0.2.0</version>
   <description>Package containing examples of how to use the rclrs API.</description>
   <maintainer email="esteve@apache.org">Esteve Fernandez</maintainer>
   <license>Apache License 2.0</license>

--- a/rosidl_generator_rs/package.xml
+++ b/rosidl_generator_rs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>rosidl_generator_rs</name>
-  <version>0.0.3</version>
+  <version>0.2.0</version>
   <description>Generate the ROS interfaces in Rust.</description>
   <author email="esteve@apache.org">Esteve Fernandez</author>
   <maintainer email="esteve@apache.org">Esteve Fernandez</maintainer>


### PR DESCRIPTION
This PR adapts the rmw implementation to the crystal API.

Building the examples currently fails with:
```
error[E0463]: can't find crate for `std_msgs`
 --> src/rclrs_subscriber.rs:2:1
  |
2 | extern crate std_msgs;
  | ^^^^^^^^^^^^^^^^^^^^^^ can't find crate
```

Are the `std_msgs` supposed to be build as part of the workspace or are they in some remote crate repo?